### PR TITLE
Enhance admin dashboard mobile layout

### DIFF
--- a/app/admin/dashboard/AdminDashboardPageClient.tsx
+++ b/app/admin/dashboard/AdminDashboardPageClient.tsx
@@ -369,7 +369,7 @@ export default function AdminDashboardPageClient({
           </a>
 
           {/* Shell updated: responsive grid with dynamic sidebar width */}
-          <div className="admin-shell grid h-svh grid-cols-[var(--sidebar-w,16rem)_1fr] transition-[grid-template-columns] duration-200 ease-out overflow-x-hidden">
+          <div className="admin-shell grid min-h-screen grid-cols-[var(--sidebar-w,16rem)_1fr] transition-[grid-template-columns] duration-200 ease-out overflow-x-hidden">
             <AdminSidebar
               activeSection={activeSection}
               setActiveSection={setActiveSection}
@@ -387,7 +387,7 @@ export default function AdminDashboardPageClient({
 
               <main
                 id="main"
-                className="flex-1 min-w-0 p-4 overflow-y-auto overflow-x-hidden"
+                className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden px-4 pt-4 pb-24 md:pb-4"
                 role="main"
                 aria-label={currentTitle}
               >
@@ -428,6 +428,15 @@ export default function AdminDashboardPageClient({
               )}
             </div>
           </div>
+
+          {isMobile && sidebarOpen && (
+            <button
+              type="button"
+              className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+              aria-label="Close sidebar"
+              onClick={() => setSidebarOpen(false)}
+            />
+          )}
 
           <Dialog open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
             <DialogContent>


### PR DESCRIPTION
## Summary
- ensure admin dashboard uses full-screen grid on mobile
- add bottom padding to prevent content being hidden behind mobile nav
- add overlay to close sidebar on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c42c37288324b7ff8052fcd47447