### PR TITLE
Improve admin environment handling and E2E stability

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,17 +19,17 @@ jobs:
       SKIP_STRICT_ENV: 1
 
       # --- your existing envs ---
-      BASE_URL: ${{ secrets.BASE_URL }}
-      NEXT_PUBLIC_BASE_URL: ${{ secrets.BASE_URL }}
-      CRON_SECRET: ${{ secrets.CRON_SECRET }}
-      PREVIEW_SECRET: ${{ secrets.PREVIEW_SECRET }}
-      ADMIN_JWT_SECRET: ${{ secrets.ADMIN_JWT_SECRET }}
+      BASE_URL: ${{ secrets.BASE_URL || 'https://flavorstudios.in' }}
+      NEXT_PUBLIC_BASE_URL: ${{ secrets.BASE_URL || 'https://flavorstudios.in' }}
+      CRON_SECRET: ${{ secrets.CRON_SECRET || 'e2e-placeholder-cron' }}
+      PREVIEW_SECRET: ${{ secrets.PREVIEW_SECRET || 'e2e-placeholder-preview' }}
+      ADMIN_JWT_SECRET: ${{ secrets.ADMIN_JWT_SECRET || 'e2e-placeholder-admin-jwt' }}
 
       # --- the ones that were missing in the log ---
       FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
       FIREBASE_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON_B64 }}
-      FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+      FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET || 'your-project.appspot.com' }}
+      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET || 'your-project.appspot.com' }}
 
       # write SA here (no VS Code complaints)
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json

--- a/app/admin/dashboard/blog/page.tsx
+++ b/app/admin/dashboard/blog/page.tsx
@@ -65,46 +65,32 @@ function BlogFallback() {
   return (
     <div
       data-testid="blog-fallback"
-      className="space-y-6"
+      className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
       aria-busy="true"
       aria-live="polite"
     >
-      <header className="space-y-2">
-        <h1
-          data-testid="page-title"
-          className="text-2xl font-semibold tracking-tight text-foreground"
+      {Array.from({ length: 4 }).map((_, i) => (
+        <article
+          key={i}
+          data-testid="blog-card"
+          className="rounded-xl border border-border bg-card p-4 shadow-sm"
+          aria-hidden="true"
         >
-          Blog
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your blog posts, drafts, and editorial calendar.
-        </p>
-      </header>
-
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <article
-            key={i}
-            data-testid="blog-card"
-            className="rounded-xl border border-border bg-card p-4 shadow-sm"
-            aria-hidden="true"
-          >
-            <div className="mb-4 flex items-start gap-3">
-              <div className="h-12 w-16 flex-shrink-0 animate-pulse rounded bg-muted" />
-              <div className="flex-1 space-y-2">
-                <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
-                <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
-              </div>
-              <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+          <div className="mb-4 flex items-start gap-3">
+            <div className="h-12 w-16 flex-shrink-0 animate-pulse rounded bg-muted" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
             </div>
-            <div className="space-y-2">
-              <div className="h-3 w-20 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-24 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-16 animate-pulse rounded bg-muted" />
-            </div>
-          </article>
-        ))}
-      </div>
+            <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+          </div>
+        </article>
+      ))}
     </div>
   );
 }
@@ -132,12 +118,23 @@ export default async function BlogPage(props: AdminBlogPageProps) {
   const resolvedSearchParams = searchParams ?? {};
   const slow = isE2ESlow(resolvedSearchParams);
   return (
-    <>
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1
+          data-testid="page-title"
+          className="text-2xl font-semibold tracking-tight text-foreground"
+        >
+          Blog
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Manage your blog posts, drafts, and editorial calendar.
+        </p>
+      </header>
       <Suspense fallback={<BlogFallback />}>
         <E2EGate enabled={slow}>
           <AdminDashboardSectionPage section={SECTION} />
         </E2EGate>
       </Suspense>
-    </>
+    </div>
   );
 }

--- a/app/admin/dashboard/components/dashboard-overview.tsx
+++ b/app/admin/dashboard/components/dashboard-overview.tsx
@@ -369,9 +369,11 @@ export default function DashboardOverview({
           >
             Dashboard data unavailable
           </h2>
-          <p className="mb-3 text-red-600">Unable to load dashboard data. Please try again.</p>
+          <p className="mb-3 text-sm text-red-700">
+            Unable to load dashboard data. Please try again.
+          </p>
           <p
-            className="mb-4 text-xs font-semibold uppercase tracking-wide text-red-500"
+            className="mb-4 text-sm font-semibold uppercase tracking-wide text-red-700"
             data-testid="dashboard-error-code"
           >
             {code}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,9 +19,7 @@ const remoteImagePatterns = imageDomains.map((hostname) => ({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true, // Add this for best practice, optional
-  experimental: {
-    allowedDevOrigins: ["http://127.0.0.1:3000", "http://localhost:3000"],
-  },
+  allowedDevOrigins: ["http://127.0.0.1:3000", "http://localhost:3000"],
   eslint: { ignoreDuringBuilds: false },
   images: {
     // Next.js image optimization is enabled.

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,89 +1,139 @@
 import "server-only";
-import { z } from "zod";
 
-const trimmedString = z
-  .string({ invalid_type_error: "Expected environment variable to be a string" })
-  .transform(value => value.trim())
-  .pipe(z.string().min(1));
+const TRUTHY = new Set(["1", "true", "yes"]);
 
-const envSchema = z
-  .object({
-    BASE_URL: trimmedString,
-    NEXT_PUBLIC_BASE_URL: trimmedString,
-    CRON_SECRET: trimmedString,
-    PREVIEW_SECRET: trimmedString,
-    ADMIN_JWT_SECRET: trimmedString,
-    FIREBASE_STORAGE_BUCKET: trimmedString,
-    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: trimmedString,
-    FIREBASE_SERVICE_ACCOUNT_JSON: trimmedString.optional(),
-    FIREBASE_SERVICE_ACCOUNT_JSON_B64: trimmedString.optional(),
-  })
-  .superRefine((value, ctx) => {
-    if (!value.FIREBASE_SERVICE_ACCOUNT_JSON && !value.FIREBASE_SERVICE_ACCOUNT_JSON_B64) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["FIREBASE_SERVICE_ACCOUNT_JSON"],
-        message: "Set FIREBASE_SERVICE_ACCOUNT_JSON or FIREBASE_SERVICE_ACCOUNT_JSON_B64",
-      });
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["FIREBASE_SERVICE_ACCOUNT_JSON_B64"],
-        message: "Set FIREBASE_SERVICE_ACCOUNT_JSON or FIREBASE_SERVICE_ACCOUNT_JSON_B64",
-      });
-    }
-  });
+const isTruthy = (value: string | undefined) =>
+  value ? TRUTHY.has(value.trim().toLowerCase()) : false;
 
-const parsed = envSchema.safeParse({
-  BASE_URL: process.env.BASE_URL,
-  NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL ?? process.env.BASE_URL,
-  CRON_SECRET: process.env.CRON_SECRET,
-  PREVIEW_SECRET: process.env.PREVIEW_SECRET,
-  ADMIN_JWT_SECRET: process.env.ADMIN_JWT_SECRET,
-  FIREBASE_STORAGE_BUCKET: process.env.FIREBASE_STORAGE_BUCKET,
-  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  FIREBASE_SERVICE_ACCOUNT_JSON: process.env.FIREBASE_SERVICE_ACCOUNT_JSON ?? process.env.FIREBASE_SERVICE_ACCOUNT_KEY,
-  FIREBASE_SERVICE_ACCOUNT_JSON_B64: process.env.FIREBASE_SERVICE_ACCOUNT_JSON_B64,
-});
+const isRelaxed =
+  isTruthy(process.env.SKIP_STRICT_ENV) ||
+  isTruthy(process.env.SKIP_ENV_VALIDATION) ||
+  process.env.NODE_ENV === "test";
 
-if (!parsed.success) {
-  const message = parsed.error.issues
-    .map(issue => {
-      const path = issue.path.join(".") || "unknown";
-      return `${path}: ${issue.message}`;
-    })
-    .join("\n");
-  throw new Error(`Invalid environment configuration\n${message}`);
+const PLACEHOLDERS = {
+  BASE_URL: "http://127.0.0.1:3000",
+  NEXT_PUBLIC_BASE_URL: "http://127.0.0.1:3000",
+  CRON_SECRET: "cron-placeholder",
+  PREVIEW_SECRET: "preview-placeholder",
+  ADMIN_JWT_SECRET: "admin-jwt-placeholder",
+  FIREBASE_STORAGE_BUCKET: "placeholder.appspot.com",
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "placeholder.appspot.com",
+} as const;
+
+type PlaceholderKey = keyof typeof PLACEHOLDERS;
+
+function normalize(value: string | undefined) {
+  return value?.trim() ?? "";
 }
 
-const envValues = parsed.data;
+function readEnv<K extends PlaceholderKey>(name: K): string;
+function readEnv(name: string, options: { required?: boolean; fallback?: string }): string | undefined;
+function readEnv(
+  name: string,
+  options: { required?: boolean; fallback?: string } = { required: true },
+): string | undefined {
+  const raw = normalize(process.env[name]);
+  if (raw) {
+    return raw;
+  }
 
-const firebaseServiceAccountJson = envValues.FIREBASE_SERVICE_ACCOUNT_JSON
-  ? envValues.FIREBASE_SERVICE_ACCOUNT_JSON
-  : envValues.FIREBASE_SERVICE_ACCOUNT_JSON_B64
-  ? Buffer.from(envValues.FIREBASE_SERVICE_ACCOUNT_JSON_B64, "base64").toString("utf8")
-  : undefined;
+  const { required = true, fallback } = options;
+
+  if (!required) {
+    if (fallback) {
+      return fallback;
+    }
+    return undefined;
+  }
+
+  if (fallback) {
+    return fallback;
+  }
+
+  if (name in PLACEHOLDERS && isRelaxed) {
+    return PLACEHOLDERS[name as PlaceholderKey];
+  }
+
+  if (isRelaxed) {
+    return "placeholder";
+  }
+
+  throw new Error(`Missing environment variable ${name}`);
+}
+
+function optionalEnv(name: string) {
+  const raw = normalize(process.env[name]);
+  return raw.length > 0 ? raw : undefined;
+}
+
+const baseUrl = readEnv("BASE_URL");
+const nextPublicBaseUrl =
+  optionalEnv("NEXT_PUBLIC_BASE_URL") || baseUrl || PLACEHOLDERS.NEXT_PUBLIC_BASE_URL;
+const cronSecret = readEnv("CRON_SECRET");
+const previewSecret = readEnv("PREVIEW_SECRET");
+const adminJwtSecret = readEnv("ADMIN_JWT_SECRET");
+
+const firebaseStorageBucket =
+  optionalEnv("FIREBASE_STORAGE_BUCKET") ||
+  optionalEnv("NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET") ||
+  (isRelaxed ? PLACEHOLDERS.FIREBASE_STORAGE_BUCKET : undefined);
+
+if (!firebaseStorageBucket) {
+  throw new Error("Missing environment variable FIREBASE_STORAGE_BUCKET");
+}
+
+const nextPublicFirebaseStorageBucket =
+  optionalEnv("NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET") ||
+  firebaseStorageBucket ||
+  PLACEHOLDERS.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+
+const firebaseServiceAccountJson = optionalEnv("FIREBASE_SERVICE_ACCOUNT_JSON");
+const firebaseServiceAccountJsonB64 = optionalEnv("FIREBASE_SERVICE_ACCOUNT_JSON_B64");
+
+let resolvedServiceAccountJson = firebaseServiceAccountJson;
+
+if (!resolvedServiceAccountJson && firebaseServiceAccountJsonB64) {
+  try {
+    resolvedServiceAccountJson = Buffer.from(
+      firebaseServiceAccountJsonB64,
+      "base64",
+    ).toString("utf8");
+  } catch (error) {
+    throw new Error(
+      `Invalid Firebase service account base64 encoding: ${
+        (error as Error).message ?? "Unknown decode error"
+      }`,
+    );
+  }
+}
+
+if (!resolvedServiceAccountJson && !isRelaxed) {
+  throw new Error("Set FIREBASE_SERVICE_ACCOUNT_JSON or FIREBASE_SERVICE_ACCOUNT_JSON_B64");
+}
 
 let firebaseServiceAccount: Record<string, unknown> | undefined;
 
-if (firebaseServiceAccountJson) {
+if (resolvedServiceAccountJson) {
   try {
-    firebaseServiceAccount = JSON.parse(firebaseServiceAccountJson) as Record<string, unknown>;
+    firebaseServiceAccount = JSON.parse(resolvedServiceAccountJson) as Record<string, unknown>;
   } catch (error) {
     throw new Error(
-      `Invalid Firebase service account JSON: ${(error as Error).message ?? "Unknown parse error"}`,
+      `Invalid Firebase service account JSON: ${
+        (error as Error).message ?? "Unknown parse error"
+      }`,
     );
   }
 }
 
 export const env = Object.freeze({
-  baseUrl: envValues.BASE_URL,
-  nextPublicBaseUrl: envValues.NEXT_PUBLIC_BASE_URL,
-  cronSecret: envValues.CRON_SECRET,
-  previewSecret: envValues.PREVIEW_SECRET,
-  adminJwtSecret: envValues.ADMIN_JWT_SECRET,
-  firebaseStorageBucket: envValues.FIREBASE_STORAGE_BUCKET,
-  nextPublicFirebaseStorageBucket: envValues.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  firebaseServiceAccountJson,
+  baseUrl,
+  nextPublicBaseUrl,
+  cronSecret,
+  previewSecret,
+  adminJwtSecret,
+  firebaseStorageBucket,
+  nextPublicFirebaseStorageBucket,
+  firebaseServiceAccountJson: resolvedServiceAccountJson,
   firebaseServiceAccount,
 });
 


### PR DESCRIPTION
## Summary
- add relaxed fallbacks for required secrets in the e2e workflow so builds can run without production env vars
- centralize server env parsing with SKIP_STRICT_ENV support and Firebase fallbacks to avoid module-load crashes
- keep the blog admin heading rendered during suspense and boost dashboard error banner contrast
- move `allowedDevOrigins` to the top level of the Next.js config to match upstream expectations

## Testing
- pnpm lint *(fails: Corepack could not download pnpm due to registry proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_690c55f69a048324ba95b735d0703652